### PR TITLE
Range check read/write offset

### DIFF
--- a/src/atomicbuffers.cc
+++ b/src/atomicbuffers.cc
@@ -25,6 +25,8 @@ using v8::Number;
 using v8::Object;
 using v8::Value;
 
+using Nan::ThrowRangeError;
+
 
 NAN_METHOD(ReadInt32) {
   Nan::HandleScope scope;
@@ -32,6 +34,10 @@ NAN_METHOD(ReadInt32) {
     return;
 
   const size_t offset = info[1]->IntegerValue();
+  const size_t length = node::Buffer::Length(info[0]);
+
+  if (offset + sizeof(int32_t) > length)
+    return ThrowRangeError("Attempt to read out of bounds");
 
   char* const ptr = node::Buffer::Data(info[0]) + offset;
   int32_t* o = reinterpret_cast<int32_t*>(ptr);
@@ -49,6 +55,10 @@ NAN_METHOD(ReadUInt32) {
     return;
 
   const size_t offset = info[1]->IntegerValue();
+  const size_t length = node::Buffer::Length(info[0]);
+
+  if (offset + sizeof(uint32_t) > length)
+    return ThrowRangeError("Attempt to read out of bounds");
 
   char* const ptr = node::Buffer::Data(info[0]) + offset;
   int32_t* o = reinterpret_cast<int32_t*>(ptr);
@@ -66,6 +76,11 @@ NAN_METHOD(WriteInt32) {
     return;
 
   const size_t offset = info[2]->IntegerValue();
+  const size_t length = node::Buffer::Length(info[0]);
+
+  if (offset + sizeof(int32_t) > length)
+    return ThrowRangeError("Attempt to write out of bounds");
+
   char* const ptr = node::Buffer::Data(info[0]) + offset;
   const int32_t value = info[1]->Uint32Value();
 
@@ -81,6 +96,11 @@ NAN_METHOD(WriteUInt32) {
     return;
 
   const size_t offset = info[2]->IntegerValue();
+  const size_t length = node::Buffer::Length(info[0]);
+
+  if (offset + sizeof(uint32_t) > length)
+    return ThrowRangeError("Attempt to write out of bounds");
+
   char* const ptr = node::Buffer::Data(info[0]) + offset;
   const uint32_t value = info[1]->Uint32Value();
 

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -32,6 +32,11 @@ describe('atomic-writes.js', function() {
       atomic.writeInt32(buf, Math.pow(2, 31), 0);
       assert.equal(buf.readInt32LE(0), - Math.pow(2, 31)); // overflows
     });
+    it('should throw on oob', function() {
+      assert.throws(function() {
+        atomic.writeInt32(buf, 0, buf.length);
+      });
+    });
   });
 
   describe('writeUInt32', function () {
@@ -56,6 +61,11 @@ describe('atomic-writes.js', function() {
       atomic.writeUInt32(buf, Math.pow(2, 32), 0);
       assert.equal(buf.readUInt32LE(0), 0); // overflows
     });
+    it('should throw on oob', function() {
+      assert.throws(function() {
+        atomic.writeUInt32(buf, 0, buf.length);
+      });
+    });
   });
 
   describe('readInt32', function () {
@@ -79,6 +89,12 @@ describe('atomic-writes.js', function() {
     it('should read ' + (Math.pow(2, 31)), function () {
       buf.writeInt32LE(Math.pow(2, 31), 0, true);
       assert.equal(atomic.readInt32(buf, 0), - Math.pow(2, 31));
+    });
+
+    it('should throw on oob', function() {
+      assert.throws(function() {
+        atomic.readInt32(buf, buf.length);
+      });
     });
   });
 
@@ -115,6 +131,12 @@ describe('atomic-writes.js', function() {
     var buf = new Buffer(16).fill(0);
     var result = atomic.writeInt32(buf, 12300, 0);
     console.log(result, buf.readUInt32LE(0), buf);
+  });
+
+  it('should throw on oob', function() {
+    assert.throws(function() {
+      atomic.readUInt32(buf, buf.length);
+    });
   });
 });
 


### PR DESCRIPTION
Make sure read/write can't be done on arbitrary memory by doing a range
check and throwing on fail.
